### PR TITLE
[v1.0-series] Add Docker devcontainer for one-click development environment.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,64 @@
+FROM docker.io/library/php:5.6-apache-stretch
+# Documentation: https://hub.docker.com/_/php
+# devcontainer additions from: https://github.com/devcontainers/images/blob/main/src/php/.devcontainer/Dockerfile
+
+# This provides a standard Debian PHP docker environment for WIND server.
+# It is the same as a production environment, with some additional
+# debug tools (like xdebug).
+
+RUN pecl channel-update pecl.php.net \
+    && yes | pecl install xdebug-2.5.5 \
+    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.client_port = 9000" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && rm -rf /tmp/pear
+
+RUN curl -sSL https://getcomposer.org/installer | php \
+    && chmod +x composer.phar \
+    && mv composer.phar /usr/local/bin/composer
+
+# Environment variables
+ENV TZ="UTC"
+ENV LANG="C.UTF-8"
+ENV LC_ALL="C.UTF-8"
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV COMPOSER_ALLOW_SUPERUSER="1"
+
+# Debian packages
+RUN echo "deb http://archive.debian.org/debian/ stretch main" > /etc/apt/sources.list
+
+# Main dependencies
+RUN apt-get update \
+    && apt-get --yes upgrade --no-install-recommends \
+    && apt-get --yes install --no-install-recommends \
+        libpng-dev \
+        mariadb-client \
+        libzip-dev \
+        unzip
+
+# PHP Core extensions
+RUN docker-php-ext-install \
+        gd \
+        mysql \
+        mysqli \
+        zip
+
+# PHP Composer extensions
+RUN mkdir -p \
+        /tmp/composer \
+        /usr/share/php/ \
+    && cd /tmp/composer \
+    && composer -n require \
+        smarty/smarty==2.6.33 \
+    && mv vendor/smarty/smarty/ /usr/share/php/ \
+    && rm -rf /tmp/composer
+
+# PHP Configuration
+RUN echo 'date.timezone="Etc/UTC"' > /usr/local/etc/php/conf.d/timezone.ini
+
+# Extra developer tools
+RUN apt-get --yes install --no-install-recommends \
+        less \
+        nano \
+        netcat

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/php-mariadb
+{
+	"name": "WIND (PHP & MariaDB)",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/var/www/html",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// For use with PHP or Apache (e.g.php -S localhost:8000 or apache2ctl start)
+	"forwardPorts": [
+		8000,
+		3306
+	],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ".devcontainer/post-create.sh",
+
+	// Configure tool-specific properties.	
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"xdebug.php-debug",
+				"bmewburn.vscode-intelephense-client",
+				"xdebug.php-pack",
+				"devsense.phptools-vscode"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services: 
+  app:
+    build:
+      context: ${VSCODE_WORKSPACE_FOLDER:-..}
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/var/www/html:cached
+      #- ..:/var/www/html:z
+    command: sleep infinity
+
+  db:
+    image: docker.io/library/mariadb:10.4
+    restart: unless-stopped
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: mariadb
+      MYSQL_DATABASE: mariadb
+      MYSQL_USER: mariadb
+      MYSQL_PASSWORD: mariadb
+
+volumes:
+  mariadb-data:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -ex
+
+# Create writable folder for WIND server
+mkdir -p \
+	config \
+	files/photos \
+	files/srtm \
+	templates/_compiled \
+	templates/_compiled/basic \
+	

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Launch built-in server and debug",
+			"type": "php",
+			"request": "launch",
+			"runtimeArgs": [
+				"-S",
+				"localhost:8000",
+				"-t",
+				"/var/www/html"
+			],
+			"port": 9003,
+			"serverReadyAction": {
+				"action": "openExternally"
+			}
+		},
+		{
+			"name": "Debug current script in console",
+			"type": "php",
+			"request": "launch",
+			"program": "${file}",
+			"cwd": "${fileDirname}",
+			"externalConsole": false,
+			"port": 9003
+		},
+		{
+			"name": "Listen for Xdebug",
+			"type": "php",
+			"request": "launch",
+			"port": 9003
+		}
+	]
+}


### PR DESCRIPTION
Works well in VS Code / Codium with the Dev Containers extension (e.g. breakpoints and single stepping are supported using xdebug).

Tries to match the PHP and extension versions currently required by WIND.